### PR TITLE
Make toml a normal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/santiagocanti/toml-checker/issues"
   },
   "homepage": "https://github.com/santiagocanti/toml-checker#readme",
-  "devDependencies": {
+  "dependencies": {
     "toml": "^2.3.3"
   }
 }


### PR DESCRIPTION
The package is required in production code and the script doesn't run without it.